### PR TITLE
Updating the Australian regions

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -110,7 +110,8 @@
             { id: 'brazilsouth', name: 'South America - Brazil South (São Paulo State)', flag: './img/br.svg' },
             { id: 'francecentral', name: 'Europe - France Central (Paris)', flag: './img/fr.svg' },
             { id: 'westeurope', name: 'Europe - West Europe (Netherlands)', flag: './img/eu.svg' },
-            { id: 'australiacentral', name: 'Asia Pacific - Australia Central (Canberra)', flag: './img/au.svg' },
+            { id: 'australiaeast', name: 'Asia Pacific - Australia East (Sydney)', flag: './img/au.svg' },
+            { id: 'australiasoutheast', name: 'Asia Pacific - Australia Southeast (Melbourne)', flag: './img/au.svg' },
           ],
         allRuntimes: [
           { id: 'DOTNET', name: '.NET' },


### PR DESCRIPTION
The Australia Central region (Canberra) is primarily used for government and not private sector, so it has limited capacity. People are better off deploying to either Australia East or Southeast, so I've added them as options instead.