### PR TITLE
Add a default runtime

### DIFF
--- a/src/main/java/io/github/nubesgen/configuration/NubesgenConfiguration.java
+++ b/src/main/java/io/github/nubesgen/configuration/NubesgenConfiguration.java
@@ -171,6 +171,11 @@ public class NubesgenConfiguration {
     }
 
     @JsonIgnore
+    public boolean isRuntimeDefault() {
+        return !isRuntimeSpring();
+    }
+
+    @JsonIgnore
     public boolean isApplicationTypeAppService() {
         return ApplicationType.APP_SERVICE.equals(this.getApplicationConfiguration().getApplicationType());
     }

--- a/src/main/resources/nubesgen/terraform/modules/app-service/main.tf.mustache
+++ b/src/main/resources/nubesgen/terraform/modules/app-service/main.tf.mustache
@@ -155,7 +155,7 @@ resource "azurerm_app_service" "application" {
     "SPRING_DATA_MONGODB_URI"      = var.azure_cosmosdb_mongodb_uri
   {{/addonCosmosdbMongodb}}
 {{/runtimeSpring}}
-{{^runtimeSpring}}
+{{#runtimeDefault}}
   {{#databaseTypeSqlServer}}
 
     "DATABASE_URL"      = var.database_url
@@ -191,6 +191,6 @@ resource "azurerm_app_service" "application" {
     "MONGODB_DATABASE" = var.azure_cosmosdb_mongodb_database
     "MONGODB_URI"      = var.azure_cosmosdb_mongodb_uri
   {{/addonCosmosdbMongodb}}
-{{/runtimeSpring}}
+{{/runtimeDefault}}
   }
 }

--- a/src/test/java/io/github/nubesgen/configuration/NubesgenConfigurationTest.java
+++ b/src/test/java/io/github/nubesgen/configuration/NubesgenConfigurationTest.java
@@ -1,0 +1,154 @@
+package io.github.nubesgen.configuration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+public class NubesgenConfigurationTest {
+
+    @Test
+    void checkConfigurationDefaultRuntime() {
+        NubesgenConfiguration properties = new NubesgenConfiguration();
+
+        assertTrue(properties.isRuntimeDocker());
+        assertTrue(properties.isRuntimeDefault());
+
+        assertFalse(properties.isRuntimeJava());
+        assertFalse(properties.isRuntimeSpring());
+        assertFalse(properties.isRuntimeMaven());
+        assertFalse(properties.isRuntimeGradle());
+        assertFalse(properties.isRuntimeDotnet());
+        assertFalse(properties.isRuntimeNodejs());
+    }
+
+    @Test
+    void checkConfigurationDockerRuntime() {
+        NubesgenConfiguration properties = new NubesgenConfiguration();
+        properties.setRuntimeType(RuntimeType.DOCKER);
+
+        assertTrue(properties.isRuntimeDocker());
+        assertTrue(properties.isRuntimeDefault());
+
+        assertFalse(properties.isRuntimeJava());
+        assertFalse(properties.isRuntimeSpring());
+        assertFalse(properties.isRuntimeMaven());
+        assertFalse(properties.isRuntimeGradle());
+        assertFalse(properties.isRuntimeDotnet());
+        assertFalse(properties.isRuntimeNodejs());
+    }
+
+    @Test
+    void checkConfigurationSpringRuntime() {
+        NubesgenConfiguration properties = new NubesgenConfiguration();
+        properties.setRuntimeType(RuntimeType.SPRING);
+
+        assertTrue(properties.isRuntimeSpring());
+        assertTrue(properties.isRuntimeJava());
+        assertTrue(properties.isRuntimeMaven());
+
+        assertFalse(properties.isRuntimeDefault());
+        assertFalse(properties.isRuntimeDocker());
+        assertFalse(properties.isRuntimeGradle());
+        assertFalse(properties.isRuntimeDotnet());
+        assertFalse(properties.isRuntimeNodejs());
+    }
+
+    @Test
+    void checkConfigurationJavaRuntime() {
+        NubesgenConfiguration properties = new NubesgenConfiguration();
+        properties.setRuntimeType(RuntimeType.JAVA);
+
+        assertTrue(properties.isRuntimeJava());
+        assertTrue(properties.isRuntimeMaven());
+        assertTrue(properties.isRuntimeDefault());
+
+        assertFalse(properties.isRuntimeSpring());
+        assertFalse(properties.isRuntimeDocker());
+        assertFalse(properties.isRuntimeGradle());
+        assertFalse(properties.isRuntimeDotnet());
+        assertFalse(properties.isRuntimeNodejs());
+    }
+
+    @Test
+    void checkConfigurationJavaGradleRuntime() {
+        NubesgenConfiguration properties = new NubesgenConfiguration();
+        properties.setRuntimeType(RuntimeType.JAVA_GRADLE);
+
+        assertTrue(properties.isRuntimeJava());
+        assertTrue(properties.isRuntimeDefault());
+        assertTrue(properties.isRuntimeGradle());
+
+        assertFalse(properties.isRuntimeSpring());
+        assertFalse(properties.isRuntimeMaven());
+        assertFalse(properties.isRuntimeDocker());
+        assertFalse(properties.isRuntimeDotnet());
+        assertFalse(properties.isRuntimeNodejs());
+    }
+
+    @Test
+    void checkConfigurationSpringGradleRuntime() {
+        NubesgenConfiguration properties = new NubesgenConfiguration();
+        properties.setRuntimeType(RuntimeType.SPRING_GRADLE);
+
+        assertTrue(properties.isRuntimeSpring());
+        assertTrue(properties.isRuntimeJava());
+        assertTrue(properties.isRuntimeGradle());
+
+        assertFalse(properties.isRuntimeDefault());
+        assertFalse(properties.isRuntimeMaven());
+        assertFalse(properties.isRuntimeDocker());
+        assertFalse(properties.isRuntimeDotnet());
+        assertFalse(properties.isRuntimeNodejs());
+    }
+
+    @Test
+    void checkConfigurationDockerSpringRuntime() {
+        NubesgenConfiguration properties = new NubesgenConfiguration();
+        properties.setRuntimeType(RuntimeType.DOCKER_SPRING);
+
+        assertTrue(properties.isRuntimeSpring());
+        assertTrue(properties.isRuntimeDocker());
+
+        assertFalse(properties.isRuntimeGradle());
+        assertFalse(properties.isRuntimeDefault());
+        assertFalse(properties.isRuntimeJava());
+        assertFalse(properties.isRuntimeMaven());
+        assertFalse(properties.isRuntimeDotnet());
+        assertFalse(properties.isRuntimeNodejs());
+    }
+
+    @Test
+    void checkConfigurationDotnetRuntime() {
+        NubesgenConfiguration properties = new NubesgenConfiguration();
+        properties.setRuntimeType(RuntimeType.DOTNET);
+
+        assertTrue(properties.isRuntimeDotnet());
+        assertTrue(properties.isRuntimeDefault());
+
+        assertFalse(properties.isRuntimeJava());
+        assertFalse(properties.isRuntimeMaven());
+        assertFalse(properties.isRuntimeSpring());
+        assertFalse(properties.isRuntimeDocker());
+        assertFalse(properties.isRuntimeGradle());
+        assertFalse(properties.isRuntimeNodejs());
+    }
+
+    @Test
+    void checkConfigurationNodeJSRuntime() {
+        NubesgenConfiguration properties = new NubesgenConfiguration();
+        properties.setRuntimeType(RuntimeType.NODEJS);
+
+        assertTrue(properties.isRuntimeNodejs());
+        assertTrue(properties.isRuntimeDefault());
+
+        assertFalse(properties.isRuntimeDotnet());
+        assertFalse(properties.isRuntimeJava());
+        assertFalse(properties.isRuntimeMaven());
+        assertFalse(properties.isRuntimeSpring());
+        assertFalse(properties.isRuntimeDocker());
+        assertFalse(properties.isRuntimeGradle());
+    }
+}

--- a/src/test/java/io/github/nubesgen/web/MainControllerTest.java
+++ b/src/test/java/io/github/nubesgen/web/MainControllerTest.java
@@ -68,7 +68,7 @@ public class MainControllerTest {
         assertTrue(entries.containsKey("terraform/modules/app-service/main.tf"));
         assertTrue(entries.get("terraform/modules/app-service/main.tf").contains("azurerm_app_service"));
         assertTrue(entries.get("terraform/modules/app-service/main.tf").contains("DOCKER|"));
-        assertTrue(entries.get(".github/workflows/gitops.yml").contains("GitOps"));
+        assertTrue(entries.get(".github/workflows/gitops.yml").contains("run: docker build"));
         assertFalse(entries.get("terraform/modules/app-service/main.tf").contains("DATABASE_URL"));
     }
 

--- a/src/test/java/io/github/nubesgen/web/MainControllerTest.java
+++ b/src/test/java/io/github/nubesgen/web/MainControllerTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -68,6 +69,7 @@ public class MainControllerTest {
         assertTrue(entries.get("terraform/modules/app-service/main.tf").contains("azurerm_app_service"));
         assertTrue(entries.get("terraform/modules/app-service/main.tf").contains("DOCKER|"));
         assertTrue(entries.get(".github/workflows/gitops.yml").contains("GitOps"));
+        assertFalse(entries.get("terraform/modules/app-service/main.tf").contains("DATABASE_URL"));
     }
 
     @Test
@@ -94,7 +96,8 @@ public class MainControllerTest {
         assertTrue(entries.containsKey("terraform/modules/app-service/main.tf"));
         assertTrue(entries.get("terraform/modules/app-service/main.tf").contains("azurerm_app_service"));
         assertTrue(entries.get("terraform/modules/app-service/main.tf").contains("JAVA|11-java11"));
-        assertTrue(entries.get(".github/workflows/gitops.yml").contains("GitOps"));
+        assertTrue(entries.get(".github/workflows/gitops.yml").contains("run: mvn package -Pprod,azure"));
+        assertFalse(entries.get("terraform/modules/app-service/main.tf").contains("DATABASE_URL"));
     }
 
     @Test
@@ -110,6 +113,7 @@ public class MainControllerTest {
         assertTrue(entries.containsKey("terraform/variables.tf"));
         assertTrue(entries.get("terraform/variables.tf").contains("myapplication"));
         assertTrue(entries.get("terraform/variables.tf").contains("westeurope"));
+        assertTrue(entries.get("terraform/modules/app-service/main.tf").contains("DATABASE_URL"));
     }
 
     @Test
@@ -126,6 +130,7 @@ public class MainControllerTest {
         assertTrue(entries.get("terraform/modules/app-service/main.tf").contains("azurerm_app_service"));
         assertTrue(entries.get("terraform/modules/app-service/main.tf").contains("JAVA|11-java11"));
         assertTrue(entries.get("terraform/modules/app-service/main.tf").contains("\"SPRING_DATASOURCE_URL\"      = \"jdbc:postgresql://${var.database_url}\""));
+        assertFalse(entries.get("terraform/modules/app-service/main.tf").contains("DATABASE_URL"));
     }
 
     @Test
@@ -175,6 +180,7 @@ public class MainControllerTest {
         assertTrue(entries.get("terraform/modules/redis/main.tf").contains("azurerm_redis_cache"));
         assertTrue(entries.containsKey("terraform/modules/storage-blob/main.tf"));
         assertTrue(entries.get("terraform/modules/storage-blob/main.tf").contains("azurerm_storage_account"));
+        assertFalse(entries.get("terraform/modules/app-service/main.tf").contains("DATABASE_URL"));
     }
 
     @Test
@@ -229,6 +235,7 @@ public class MainControllerTest {
         assertTrue(entries.get("terraform/modules/app-service/main.tf").contains("size = \"S1\""));
         assertTrue(entries.containsKey("terraform/modules/mysql/main.tf"));
         assertTrue(entries.get("terraform/modules/mysql/main.tf").contains("sku_name                          = \"GP_Gen5_2\""));
+        assertTrue(entries.get("terraform/modules/app-service/main.tf").contains("DATABASE_URL"));
     }
 
     @TestConfiguration


### PR DESCRIPTION
I don't know about the name `isRuntimeDefault`. If you look at `NubesgenConfigurationTest` you realize that Java, DotNet, NodeJS, Docker are all considered `default`. Maybe a different name, but as we all know _naming is hard_. For now the method is just: 

```
public boolean isRuntimeDefault() {
  return !isRuntimeSpring();
}
```

But it will end up being:

```
public boolean isRuntimeDefault() {
  return !isRuntimeSpring() && !isRuntimeQuarkus() && !isRuntimeMicronaut();
}
```