### PR TITLE
Terraform - various fixes / improvements around network

### DIFF
--- a/src/main/resources/nubesgen/terraform/modules/cosmosdb-mongodb/main.tf.mustache
+++ b/src/main/resources/nubesgen/terraform/modules/cosmosdb-mongodb/main.tf.mustache
@@ -36,6 +36,8 @@ resource "azurerm_cosmosdb_account" "cosmosdb" {
   }
   {{#NetworkVNet}}
 
+  is_virtual_network_filter_enabled = true
+
   virtual_network_rule {
     id = var.subnet_id
   }

--- a/src/main/resources/nubesgen/terraform/modules/key-vault/main.tf.mustache
+++ b/src/main/resources/nubesgen/terraform/modules/key-vault/main.tf.mustache
@@ -40,7 +40,7 @@ resource "azurerm_key_vault" "application" {
   {{#NetworkVNet}}
 
   network_acls {
-    default_action             = "Allow"
+    default_action             = "Deny"
     bypass                     = "None"
     virtual_network_subnet_ids = [var.subnet_id]
   }

--- a/src/main/resources/nubesgen/terraform/modules/postgresql/main.tf.mustache
+++ b/src/main/resources/nubesgen/terraform/modules/postgresql/main.tf.mustache
@@ -39,6 +39,7 @@ resource "azurerm_postgresql_server" "database" {
   auto_grow_enabled            = true
   version                      = "11"
   ssl_enforcement_enabled      = true
+  ssl_minimal_tls_version_enforced  = "TLS1_2"
 
   tags = {
     "environment"      = var.environment

--- a/src/main/resources/nubesgen/terraform/modules/storage-blob/main.tf.mustache
+++ b/src/main/resources/nubesgen/terraform/modules/storage-blob/main.tf.mustache
@@ -30,7 +30,7 @@ resource "azurerm_storage_account" "storage-blob" {
 resource "azurerm_storage_account_network_rules" "storage_only_app_traffic" {
   storage_account_id = azurerm_storage_account.storage-blob.id
 
-  default_action             = "Allow"
+  default_action             = "Deny"
   virtual_network_subnet_ids = [var.subnet_id]
 }
 {{/NetworkVNet}}

--- a/src/test/resources/nubesgen/terraform/function-vnet-java/terraform/variables.tf
+++ b/src/test/resources/nubesgen/terraform/function-vnet-java/terraform/variables.tf
@@ -24,11 +24,11 @@ variable "address_space" {
 variable "app_subnet_prefix" {
   type        = string
   description = "Application subnet prefix"
-  default     = "10.11.0.0/16"
+  default     = "10.11.0.0/24"
 }
 
 variable "redis_subnet_prefix" {
   type        = string
   description = "Redis cache subnet prefix"
-  default     = "10.11.3.0/24"
+  default     = "10.11.1.0/24"
 }


### PR DESCRIPTION
With @baptisteohanes, we reviewed several tf modules & tests around network.

Key findings:
-  CosmosDB TF module: provisionning failed, missing `is_virtual_network_filter_enabled` parameter.
- Keyvault & Storage Account TF modules: wrong network configuration, "All networks" were still enabled on Networking configuration, `default_action` value should be **False**.  
- PostgreSQL TF modules: Minimal TLS version 1.2 added (already defined for MySQL)
- function-vnet-java: fix wrong subnets ranges provided (provisionning failed)

Areas of improvement (**not part of this PR**):
- Azure Cache for Redis: add Network Security Group (based on [inbounds](https://docs.microsoft.com/en-US/azure/azure-cache-for-redis/cache-how-to-premium-vnet#inbound-port-requirements) and [outbounds](https://docs.microsoft.com/en-US/azure/azure-cache-for-redis/cache-how-to-premium-vnet#outbound-port-requirements) requirements) add attach it to redis subnet.
- app-service-vnet-spring test: change PostgreSQL sku used by this test:
`Error: waiting for creation of Virtual Network Rule "psqlvn-nubesgen-testapp-vnet-dev" (PostgreSQL Server: "psql-nubesgen-testapp-vnet-dev", Resource Group: "rg-nubesgen-testapp-vnet-dev"): Code="FeatureNotSupportedForEdition" Message="This feature is not available for the selected edition 'Basic'."`
