### PR TITLE
Remove unneeded dependsOn

### DIFF
--- a/rest-server/src/main/resources/nubesgen/bicep/modules/function/function.bicep.mustache
+++ b/rest-server/src/main/resources/nubesgen/bicep/modules/function/function.bicep.mustache
@@ -112,11 +112,6 @@ resource functionApp 'Microsoft.Web/sites@2020-06-01' = {
       ])
     }
   }
-
-  dependsOn: [
-    hostingPlan
-    storageAccount
-  ]
 }
 
 output application_url string = functionApp.properties.hostNames[0]


### PR DESCRIPTION
My Bicep linter says this dependsOn is unnecessary, and I haven't seen it in similar examples, like the azd templates.