### PR TITLE
Add support for Python runtime to functions

### DIFF
--- a/rest-server/src/main/resources/nubesgen/bicep/modules/function/function.bicep.mustache
+++ b/rest-server/src/main/resources/nubesgen/bicep/modules/function/function.bicep.mustache
@@ -75,6 +75,9 @@ resource functionApp 'Microsoft.Web/sites@2020-06-01' = {
 {{#runtimeNodejs}}
       linuxFxVersion: 'Node|16'
 {{/runtimeNodejs}}
+{{#runtimePython}}
+      linuxFxVersion: 'Python|3.9'
+{{/runtimePython}}
       appSettings: union(environmentVariables, [
         
         // {
@@ -100,6 +103,9 @@ resource functionApp 'Microsoft.Web/sites@2020-06-01' = {
 {{#runtimeNodejs}}
           'value': 'node'
 {{/runtimeNodejs}}           
+{{#runtimePython}}
+          'value': 'python'
+{{/runtimePython}}
         }
         {
           name: 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING'

--- a/rest-server/src/main/resources/nubesgen/bicep/modules/function/function.bicep.mustache
+++ b/rest-server/src/main/resources/nubesgen/bicep/modules/function/function.bicep.mustache
@@ -104,7 +104,7 @@ resource functionApp 'Microsoft.Web/sites@2020-06-01' = {
           'value': 'node'
 {{/runtimeNodejs}}           
 {{#runtimePython}}
-          'value': 'python'
+          value: 'python'
 {{/runtimePython}}
         }
         {


### PR DESCRIPTION
This PR adds the appropriate values for Python runtime in functions template. Latest Python version is 3.9, hoping for 3.10 support soon, so we should change version in future once 3.10 is generally available.

I see support for Python in the UI and a `runtimePython` variable in other templates, so I think this would work, but I haven't actually tested the change. I can try to get NubesGen running if you'd like, it's been a while since I did Java dev.