### PR TITLE
Update main.bicep.mustache with lint fix

### DIFF
--- a/rest-server/src/main/resources/nubesgen/bicep/main.bicep.mustache
+++ b/rest-server/src/main/resources/nubesgen/bicep/main.bicep.mustache
@@ -7,8 +7,8 @@ param location string = '{{region}}'
 var instanceNumber = '001'
 
 var defaultTags = {
-  'environment': environment
-  'application': applicationName
+  environment: environment
+  application: applicationName
   'nubesgen-version': '{{nubesgenVersion}}'
 }
 


### PR DESCRIPTION
Bicep prefers unquoted property names when possible.
Did a test deploy with my fix locally.