### PR TITLE
Update doc to mention installing Rosetta to execute macos x86_64 binary on Apple Silicon

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -56,6 +56,7 @@ To run the binary on Linux, you need to:
 To run the binary on a Mac OS, you need to:
 
 - Download the latest release: `gh release download --repo microsoft/nubesgen --pattern='nubesgen-cli-macos'`
+- If on Apple Silicon, install Rosetta if it's not already installed: `/usr/sbin/softwareupdate --install-rosetta --agree-to-license`
 - Make the binary executable: `chmod +x nubesgen-cli-macos`
 - Allow Mac OS X to execute it: `xattr -d com.apple.quarantine nubesgen-cli-macos`
 - Run the binary: `./nubesgen-cli-macos -h`

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -46,6 +46,7 @@ To run the binary on Linux, you need to:
    To run the binary on a Mac OS, you need to:
 
    - Download the latest release: `gh release download --repo microsoft/nubesgen --pattern='nubesgen-cli-macos'`
+   - If on Apple Silicon, install Rosetta if it's not already installed: `/usr/sbin/softwareupdate --install-rosetta --agree-to-license`
    - Make the binary executable: `chmod +x nubesgen-cli-macos`
    - Allow Mac OS X to execute it: `xattr -d com.apple.quarantine nubesgen-cli-macos`
    - Run the binary: `./nubesgen-cli-macos -h`

--- a/docs/gitops/gitops-quick-start.md
+++ b/docs/gitops/gitops-quick-start.md
@@ -53,6 +53,7 @@ Full documentation for the NubesGen CLI is available [here](/getting-started/cli
    To run the binary on a Mac OS, you need to:
 
    - Download the latest release: `gh release download --repo microsoft/nubesgen --pattern='nubesgen-cli-macos'`
+   - If on Apple Silicon, install Rosetta if it's not already installed: `/usr/sbin/softwareupdate --install-rosetta --agree-to-license`
    - Make the binary executable: `chmod +x nubesgen-cli-macos`
    - Allow Mac OS X to execute it: `xattr -d com.apple.quarantine nubesgen-cli-macos`
    - Setup GitOps: `./nubesgen-cli-macos gitops`


### PR DESCRIPTION
Fixes #460 MacOS binary CPU architecture incompatible with Apple Silicon M2

The macos binary compiled by the `macos-*` Github Action runner is a `x86_64` architecture binary, it's not an `arm64` binary so it requires Rosetta to run on Apple Silicon.

This PR updates the documentation to mention installing Rosetta prior to executing the binary if on Apple Silicon. Not that contrary to graphical applications, MacOS will not automatically offer user to install Rosetta when executing a `x86_64` binary on the command line.
