### PR TITLE
Generate MacOS arm64 CLI binary in addition to x64 binary

### DIFF
--- a/.github/workflows/cli-continuous-integration.yml
+++ b/.github/workflows/cli-continuous-integration.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         jdk-version: ['21']
-        os: [ubuntu-22.04, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, macos-latest-xlarge, windows-latest]
     steps:
       - name: Download application package
         uses: actions/download-artifact@v3
@@ -60,9 +60,12 @@ jobs:
       - name: Build native image on Linux
         run: native-image --enable-url-protocols=https --static -jar nubesgen-cli-*.jar nubesgen-cli-linux
         if: runner.os == 'Linux'
-      - name: Build native image on Mac OS X
+      - name: Build native image on Mac OS X (arm64)
+        run: native-image --enable-url-protocols=https -jar nubesgen-cli-*.jar nubesgen-cli-macos-arm64
+        if: runner.os == 'macOS' && runner.arch == 'ARM64'
+      - name: Build native image on Mac OS X (x64)
         run: native-image --enable-url-protocols=https -jar nubesgen-cli-*.jar nubesgen-cli-macos
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && runner.arch == 'X64'
       - name: Build native image on Windows
         run: native-image --enable-url-protocols=https -jar nubesgen-cli-*.jar nubesgen-cli-windows
         if: runner.os == 'Windows'

--- a/.github/workflows/cli-continuous-integration.yml
+++ b/.github/workflows/cli-continuous-integration.yml
@@ -46,7 +46,11 @@ jobs:
     strategy:
       matrix:
         jdk-version: ['21']
-        os: [ubuntu-22.04, macos-latest, macos-latest-xlarge, windows-latest]
+        os:
+          - ubuntu-22.04
+          - macos-latest # Intel x64
+          - macos-latest-xlarge # Apple Silicon arm64
+          - windows-latest
     steps:
       - name: Download application package
         uses: actions/download-artifact@v3
@@ -60,12 +64,12 @@ jobs:
       - name: Build native image on Linux
         run: native-image --enable-url-protocols=https --static -jar nubesgen-cli-*.jar nubesgen-cli-linux
         if: runner.os == 'Linux'
-      - name: Build native image on Mac OS X (arm64)
-        run: native-image --enable-url-protocols=https -jar nubesgen-cli-*.jar nubesgen-cli-macos-arm64
-        if: runner.os == 'macOS' && runner.arch == 'ARM64'
-      - name: Build native image on Mac OS X (x64)
+      - name: Build native image on Mac OS X (Intel x64)
         run: native-image --enable-url-protocols=https -jar nubesgen-cli-*.jar nubesgen-cli-macos
         if: runner.os == 'macOS' && runner.arch == 'X64'
+      - name: Build native image on Mac OS X (Apple Silicon arm64)
+        run: native-image --enable-url-protocols=https -jar nubesgen-cli-*.jar nubesgen-cli-macos-arm64
+        if: runner.os == 'macOS' && runner.arch == 'ARM64'
       - name: Build native image on Windows
         run: native-image --enable-url-protocols=https -jar nubesgen-cli-*.jar nubesgen-cli-windows
         if: runner.os == 'Windows'


### PR DESCRIPTION
Fixes #460

Github just released a new Apple Silicon M1 runner we can use to compile natively to `arm64`:
https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/

This PR adds the `macos-latest-xlarge` runner to the matrix which compiles an `arm64` binary that can natively be run on Apple Silicon without Rosetta.

It keeps the previous binary name `nubesgen-cli-macos` for x64 and introduces the new `nubesgen-cli-macos-arm64` binary name for Apple Silicon.
